### PR TITLE
Crash fix for IllegalStateException:Cannot call addOnDrawListener ins…

### DIFF
--- a/android-page-load-instrumentation/src/main/java/tech/okcredit/page_load/NextDrawListener.kt
+++ b/android-page-load-instrumentation/src/main/java/tech/okcredit/page_load/NextDrawListener.kt
@@ -6,6 +6,7 @@ import android.os.Looper
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import android.view.ViewTreeObserver.OnDrawListener
+import java.lang.Exception
 
 
 internal class NextDrawListener(
@@ -32,10 +33,18 @@ internal class NextDrawListener(
     }
 
     fun safelyRegisterForNextDraw(): NextDrawListener {
-        if (Build.VERSION.SDK_INT >= 26 || (view.viewTreeObserver.isAlive && view.isAttachedToWindow)) {
-            view.viewTreeObserver.addOnDrawListener(this)
-        } else {
-            view.addOnAttachStateChangeListener(this)
+        /***  AddOnDrawListener can't be called inside onDraw. Due to some raise conditions,
+         * there is a crash for 0.005% of the time. So we are doing a post call for fixing this.*/
+        mainHandler.post {
+            try {
+                if (Build.VERSION.SDK_INT >= 26 || (view.viewTreeObserver.isAlive && view.isAttachedToWindow)) {
+                    view.viewTreeObserver.addOnDrawListener(this)
+                } else {
+                    view.addOnAttachStateChangeListener(this)
+                }
+            } catch (e: Exception) {
+
+            }
         }
         return this
     }


### PR DESCRIPTION
AddOnDrawListener can't be called inside onDraw. Due to some raise conditions, there is a crash for 0.005% of the time. So we are doing a post-call for fixing this

Crash Log: 
```
Fatal Exception: java.lang.IllegalStateException: Cannot call addOnDrawListener inside of onDraw
       at android.view.ViewTreeObserver.addOnDrawListener(ViewTreeObserver.java:717)
       at tech.okcredit.page_load.NextDrawListener.safelyRegisterForNextDraw(NextDrawListener.java:36)
       at tech.okcredit.page_load.NextDrawListener$Companion.onNextDraw(NextDrawListener.java:56)
       at tech.okcredit.page_load.PageLoadTracker$onFirstDrawListener$2.invokeSuspend(PageLoadTracker.kt:23)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```